### PR TITLE
Made include path use macros instead of C:\Users\Administrator\Desktop

### DIFF
--- a/nSkinz/nSkinz.vcxproj
+++ b/nSkinz/nSkinz.vcxproj
@@ -126,14 +126,14 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>C:\local\boost_1_63_0;C:\Users\Administrator\Desktop\nSkinz\nSkinz\deps;C:\Users\Administrator\Desktop\nSkinz\nSkinz\deps\imgui;$(IncludePath)</IncludePath>
+    <IncludePath>C:\local\boost_1_63_0;$(ProjectDir)deps;$(ProjectDir)deps\imgui;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>C:\local\boost_1_63_0;C:\Users\Administrator\Desktop\nSkinz\nSkinz\deps;C:\Users\Administrator\Desktop\nSkinz\nSkinz\deps\imgui;$(IncludePath)</IncludePath>
+    <IncludePath>C:\local\boost_1_63_0;$(ProjectDir)deps;$(ProjectDir)deps\imgui;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>

--- a/nSkinz/nSkinz.vcxproj.filters
+++ b/nSkinz/nSkinz.vcxproj.filters
@@ -29,6 +29,7 @@
     <ClCompile Include="src\Utilities\Platform.cpp">
       <Filter>Utilities</Filter>
     </ClCompile>
+    <ClCompile Include="src\ItemDefinitions.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\Configuration.hpp" />
@@ -124,7 +125,6 @@
     <ClInclude Include="src\Utilities\FnvHash.hpp">
       <Filter>Utilities</Filter>
     </ClInclude>
-    <ClInclude Include="src\ItemDefinitions.cpp" />
     <ClInclude Include="src\ItemDefinitions.hpp" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The location of boost doesn't use macros, maybe it should be included in deps?